### PR TITLE
writethrough跟none的解释可能弄反了？

### DIFF
--- a/virtual/virtual_002.md
+++ b/virtual/virtual_002.md
@@ -50,14 +50,14 @@ QEMU虚拟磁盘的的参数 "cache=XXX" 有5种，如下表，其实在实现�
 || BDRV_REQ_FUA | BDRV_O_NOCACHE | BDRV_O_NO_FLUSH |
 |--------|--------|--------|-------|
 |writeback|❌|❌|❌|
-|writethrough|✅|❌|❌|
-|none|❌|✅|❌|
+|writethrough|❌|✅|❌|
+|none|✅|❌|❌|
 |directsync|✅|✅|❌|
 |unsafe|❌|❌|✅|
 
-**none** 对应的`O_NOCACHE`的实现方式是在open()中加入`O_DIRECT`参数。
+**writethrough** 对应的`O_NOCACHE`的实现方式是在open()中加入`O_DIRECT`参数。
 
-**writethrough** 对应的`BDRV_REQ_FUA`会调用bdrv注册的`bdrv_co_flush`函数，进而调用bdrv注册的`bdrv_co_flush_to_os`(刷qemu自身的元数据cache，如qcow2 lookup table)和`bdrv_co_flush_to_disk`函数(把数据真正刷到磁盘，如file-posix的fsync或fdatasync)。
+**none** 对应的`BDRV_REQ_FUA`会调用bdrv注册的`bdrv_co_flush`函数，进而调用bdrv注册的`bdrv_co_flush_to_os`(刷qemu自身的元数据cache，如qcow2 lookup table)和`bdrv_co_flush_to_disk`函数(把数据真正刷到磁盘，如file-posix的fsync或fdatasync)。
 
 **writeback** 是则是利用了host page cache，并且不会在每次写操作后进行sync操作。
 


### PR DESCRIPTION
根据QEMU文档
![image](https://user-images.githubusercontent.com/44110085/141126661-982f7fa6-e3a4-4212-8ac0-8eb011dcc0c8.png)

感觉writethrough类似O_DIRECT，不过pagecache，数据不确保落盘
none类似O_SYNC，过pagecache且fsync进磁盘

https://www.qemu.org/docs/master/system/invocation.html#hxtool-1